### PR TITLE
ChatKitにお絵かきツール選択UIを表示

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -68,7 +68,18 @@ export const Chat: FunctionComponent<{ open: boolean; sendCanvas: string }> = ({
         return clientSecret;
       },
     },
-    composer: { attachments: { enabled: true } },
+    composer: {
+      attachments: { enabled: true },
+      tools: [
+        {
+          id: "image_generation",
+          label: "お絵かき",
+          icon: "images",
+          placeholderOverride: "描いてほしい絵を入力",
+          pinned: true,
+        },
+      ],
+    },
   });
 
   if (!userID) {


### PR DESCRIPTION
## 変更内容
- ChatKit composer に `お絵かき` のツール選択 UI を表示します。
- tool id は Agents SDK / Responses API の hosted tool type に合わせて `image_generation` にしています。

## 現状の制約
- premy は ChatKit managed / Agent Builder workflow を使っています。
- ChatKit.js の managed vs self-hosted 比較では、composer の tool menu / model picker は self-hosted backend 側の機能として示されています。
- 参考: https://openai.github.io/chatkit-js/
- 現在の workflow 入力は `input_as_text` のみで、composer の selected tool を workflow 側に渡して `modelSettings.toolChoice` に反映する経路が見えていません。
- そのため、この PR は「明示的な入口を UI に置く」までで、Agent Builder の `imageGenerationTool` を確実に選択・強制する対応ではありません。

## 確認
- `npm test`
- `git diff --check`